### PR TITLE
Clean up `ad_threepoint` integrator

### DIFF
--- a/mimt/integrators/ad_threepoint.py
+++ b/mimt/integrators/ad_threepoint.py
@@ -199,7 +199,7 @@ class ThreePointIntegrator(ADIntegrator):
             # Transform the solid angle sample into a surface sample
             # (the reparameterization for the first intersection happens on the caller side)
             if it > 0:
-                D = solid_to_surface_reparam_det(si, prev_si.p)
+                D = solid_to_surface_reparam_det(si, prev_si.p, active=active_next)
                 β *= det_over_det(D)
 
             Le = β * mis * ds.emitter.eval(si, active_next)
@@ -228,7 +228,7 @@ class ThreePointIntegrator(ADIntegrator):
 
             # For environment emitters, `si_em` will be invalid, in which
             # case `D_em` is one, and the sample is processed as being a solid angle sample.
-            D_em = solid_to_surface_reparam_det(si_em, si.p)
+            D_em = solid_to_surface_reparam_det(si_em, si.p, active=active_em)
 
             wo_em = si.to_local(ray_em.d)
             bsdf_value_em, bsdf_pdf_em = bsdf.eval_pdf(bsdf_ctx, si, wo_em, active_em)

--- a/mimt/integrators/common.py
+++ b/mimt/integrators/common.py
@@ -4,7 +4,7 @@ import mitsuba as mi
 def det_over_det(D):
     return dr.select(D != 0, dr.replace_grad(1, D/dr.detach(D)), 0)
 
-def solid_to_surface_reparam_det(si: mi.SurfaceInteraction3f, x_prev: mi.Point3f):
+def solid_to_surface_reparam_det(si: mi.SurfaceInteraction3f, x_prev: mi.Point3f, active: mi.Bool = True):
     """ Reparameterization determinant from solid angles to surface elements
     """
 
@@ -15,7 +15,7 @@ def solid_to_surface_reparam_det(si: mi.SurfaceInteraction3f, x_prev: mi.Point3f
 
     # If the intersection point lies on an environment emitter, 
     # the surface parameterization is invalid (and si.is_valid() == False)
-    det = dr.select(si.is_valid() & (distance_squared > 0), 
+    det = dr.select(active & si.is_valid() & (distance_squared > 0), 
                     dr.norm(dr.cross(si.dp_du, si.dp_dv)) * dr.abs(cos_theta) / distance_squared, 1)
 
     return det


### PR DESCRIPTION
This PR cleans up the `ad_threepoint` integrator and fixes a couple of (minor) issues:
* Trace each ray only once (reuse `si_next` as `si`)
* Fix sensor measurement not considering sensor-to-solid angle determinant
* Fix `D` at sensor not considering movement of the first hit (`ray.d` in `render_forward` does not follow the shape)
* Introduce convenience functions for the various reparameterization determinants