### PR TITLE
PRB Cleanup

### DIFF
--- a/mimt/integrators/ad_threepoint.py
+++ b/mimt/integrators/ad_threepoint.py
@@ -218,12 +218,14 @@ class ThreePointIntegrator(ADIntegrator):
 
             active_em &= (ds_em.pdf != 0.0)
             
-            # Recompute the sample position for si_em.dp_du and si_em.dp_dv
+            # Retrace the emitter ray so that the intersection point follows the emitter,
+            # and to obtain an intersection point with the differentials si_em.dp_du and si_em.dp_dv
+            # (only if the emitter is a surface)
             ray_em = si.spawn_ray(ds_em.d)
             si_em  = scene.ray_intersect(dr.detach(ray_em), 
                                          ray_flags=mi.RayFlags.All | mi.RayFlags.FollowShape,
                                          coherent=mi.Bool(False),
-                                         active=active_em)
+                                         active=active_em & mi.has_flag(ds_em.emitter.flags(), mi.EmitterFlags.Surface))
             ray_em.d = dr.select(si_em.is_valid(), dr.normalize(si_em.p - si.p), ray_em.d)
 
             # For environment emitters, `si_em` will be invalid, in which

--- a/mimt/integrators/prb_threepoint.py
+++ b/mimt/integrators/prb_threepoint.py
@@ -386,7 +386,9 @@ class PRBThreePointIntegrator(RBIntegrator):
 
             ray_em = si.spawn_ray(ds_em.d)
             with dr.resume_grad(when=not primal):
-                # Retrace the emitter ray so that the intersection point follows the emitter (if it is a surface)
+                # Retrace the emitter ray so that the intersection point follows the emitter,
+                # and to obtain an intersection point with the differentials si_em.dp_du and si_em.dp_dv
+                # (only if the emitter is a surface)
                 si_em = scene.ray_intersect(ray_em, 
                                             ray_flags=mi.RayFlags.All | mi.RayFlags.FollowShape,
                                             coherent=mi.Bool(False),


### PR DESCRIPTION
This PR cleans up the `prb_threepoint` integrator:
* Use the convenience functions for reparameterizing determinants
* Performance: trace each ray in the primal/adjoint phase only once (share intersection points over loop iterations)
* Performance: share first intersection point between primal and adjoint phase (it is cached anyway for the Jacobian determinant at the sensor)
* Performance: retrace emitter rays only if the sampled emitter has a surface (also implemented in `ad_threepoint`)